### PR TITLE
fix(release): fix github action commits signature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Set up GPG
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import
+          git config --global user.signingkey ${{ secrets.GPG_KEY_ID }}
+          git config --global commit.gpgSign true
+
       - name: Release
         uses: cycjimmy/semantic-release-action@v4
         with:


### PR DESCRIPTION
This pull request addresses an issue with the GitHub Actions workflow for semantic releases. The previous configuration resulted in unverified commit signatures, which caused the release process to fail.

Changes Made
Updated the GitHub Actions workflow to configure commit signing using GPG keys.
Added steps to import the GPG key and configure Git to sign commits automatically.